### PR TITLE
Adding generated supplementary-style-guide guide rules

### DIFF
--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/AMD64.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/AMD64.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#AMD64
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Hammer|x86_64|x86-64|x64|64-bit x86 : AMD64

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/Bps.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/Bps.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#Bps
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    bps : Bps

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/DVD-writer.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/DVD-writer.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#DVD-writer
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    DVD burner|burner : DVD writer

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/UltraSPARC.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/UltraSPARC.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#UltraSPARC
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    ULTRASPARC|UltraSparc|or other variations. : UltraSPARC

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/air-gap.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/air-gap.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#air-gap
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    air wall : air gap

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/app.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/app.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#app
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    app. : app

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/auto-detect.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/auto-detect.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#auto-detect
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    autodetect : auto-detect

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bare-metal-adj.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bare-metal-adj.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#bare-metal-adj
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    baremetal|bare metal : bare-metal

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bare-metal-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bare-metal-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#bare-metal-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    baremetal|bare-metal : bare metal

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bimonthly.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bimonthly.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#bimonthly
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    bi-monthly : bimonthly

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bind.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bind.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#bind
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Bind|bind : BIND

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bios.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bios.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#bios
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Bios : BIOS

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/biweekly.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/biweekly.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#biweekly
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    bi-weekly : biweekly

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/boot-disk.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/boot-disk.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#boot-disk
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    boot diskette : boot disk

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/boot-loader.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/boot-loader.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#boot-loader
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    bootloader : boot loader

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bottleneck.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bottleneck.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#bottleneck
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    bottle neck|bottle-neck : bottleneck

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bps.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bps.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#bps
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Bps : bps

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/broadcast-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/broadcast-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#broadcast-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    broad cast|broad-cast : broadcast

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/broadcast-v.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/broadcast-v.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#broadcast-v
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    broad cast|broad-cast : broadcast

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/btrfs.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/btrfs.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#btrfs
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    btrfs : Btrfs

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bug-fix.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/bug-fix.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#bug-fix
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    bugfix : bug fix

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/built-in.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/built-in.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#built-in
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    builtin|built in : built-in

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cap-ex.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cap-ex.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cap-ex
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Capex|capex|capEx : CapEx

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cd-command.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cd-command.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cd-command
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    CD : cd

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cd-one.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cd-one.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cd-one
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    CD 1 : CD #1

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cd-writer.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cd-writer.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cd-writer
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    CD burner|burner : CD writer

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cds.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cds.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cds
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    CDS|Cds : CDs

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cgroup.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cgroup.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cgroup
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    CGroup|c group : cgroup

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ciphertext.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ciphertext.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ciphertext
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    cipher text|cyphertext|cypher text|cipher-text|cypher-text : ciphertext

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/client-side-adj.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/client-side-adj.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#client-side-adj
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    client side : client-side

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/client-side-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/client-side-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#client-side-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    client-side : client side

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cloud-adj.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cloud-adj.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cloud-adj
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Cloud : cloud

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cloud-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cloud-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cloud-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Cloud : cloud

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cloudbursting.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cloudbursting.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cloudbursting
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    cloud-bursting : cloudbursting

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cloudwashing.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cloudwashing.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cloudwashing
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    cloud-washing : cloudwashing

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/colocate.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/colocate.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#colocate
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    co-locate|collocate : colocate

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/comma-delimited.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/comma-delimited.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#comma-delimited
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    comma delimited|commadelimited : comma-delimited

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/comma-separated-values.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/comma-separated-values.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#comma-separated-values
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    comma-delimited values|comma delimited values|comma separated values : comma-separated values

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/command-driven.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/command-driven.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#command-driven
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    command driven|commanddriven : command-driven

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/command-language.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/command-language.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#command-language
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    command-language : command language

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/compact-disk.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/compact-disk.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#compact-disk
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    cd : CD

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/container-based.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/container-based.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#container-based
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    container based : container-based

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/containerized.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/containerized.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#containerized
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    containerised : containerized

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cross-platform.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cross-platform.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cross-platform
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    crossplatform|cross platform : cross-platform

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cross-site-scripting.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cross-site-scripting.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cross-site-scripting
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    cross site scripting : cross-site scripting

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/csv.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/csv.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#csv
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    csv : CSV

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ctrl.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ctrl.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ctrl
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    control key|ctrl : Ctrl

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cygmon.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/cygmon.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#cygmon
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    CygMon|cygmon|CYGMON : Cygmon

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/daisy-chain-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/daisy-chain-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#daisy-chain-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    daisy-chain|daisychain : daisy chain

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/daisy-chain-v.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/daisy-chain-v.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#daisy-chain-v
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    daisy-chain|daisychain : daisy chain

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/data-center.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/data-center.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#data-center
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    datacenter|data-center|data centre|datacentre : data center

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/data-mirroring.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/data-mirroring.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#data-mirroring
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    datamirroring|data-mirroring : data mirroring

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/data-path-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/data-path-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#data-path-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    datapath : data path

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/debug-adj.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/debug-adj.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#debug-adj
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    de-bug : debug

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/debug-v.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/debug-v.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#debug-v
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    de-bug : debug

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/denial-of-service-adj.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/denial-of-service-adj.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#denial-of-service-adj
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Denial-of-Service : denial-of-service

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/denial-of-service-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/denial-of-service-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#denial-of-service-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Denial of Service : denial of service

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/desktop-adj.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/desktop-adj.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#desktop-adj
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    desk top|desk-top : desktop

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/desktop-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/desktop-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#desktop-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    desk top|desk-top : desktop

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/devops-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/devops-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#devops-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    devops|Devops|Dev-Ops|Dev Ops : DevOps

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/different.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/different.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#different
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    different than|different to : different from

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/disk-druid.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/disk-druid.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#disk-druid
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Disk druid|disk druid|diskdruid : Disk Druid

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/disk-label.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/disk-label.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#disk-label
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    disklabel|disk-label : disk label

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/dns.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/dns.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#dns
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    dns : DNS

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/domain-name.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/domain-name.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#domain-name
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    domainname|domain-name : domain name

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/download-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/download-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#download-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    down-load|down load : download

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/download-v.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/download-v.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#download-v
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    down-load|down load : download

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/downstream-adj.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/downstream-adj.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#downstream-adj
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    down-stream|down stream : downstream

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/downstream-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/downstream-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#downstream-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    down-stream|down stream : downstream

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/dual-boot.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/dual-boot.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#dual-boot
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    dualboot|dual boot : dual-boot

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/emit.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/emit.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#emit
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    send out : emit

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/enter-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/enter-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#enter-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    enter : Enter

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/environment.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/environment.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#environment
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    env : environment

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/examine.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/examine.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#examine
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    look at : examine

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/exec-shield.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/exec-shield.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#exec-shield
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Exec Shield : Exec-Shield

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/exif.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/exif.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#exif
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    EXIF|exif : Exif

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/faq.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/faq.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#faq
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Faq|faq|F.A.Q : FAQ

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/fedora-project.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/fedora-project.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#fedora-project
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    fedora project : Fedora™ Project

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/firmware.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/firmware.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#firmware
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    firm ware|firm-ware : firmware

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/floating-point.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/floating-point.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#floating-point
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    floating-point : floating point

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/foreground.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/foreground.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#foreground
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    fore-ground|forground : foreground

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/fortran.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/fortran.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#fortran
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    fortran : Fortran

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/fqdn.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/fqdn.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#fqdn
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Fqdn|fqdn : FQDN

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gb.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gb.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#gb
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    gb|Gb : GB

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gbps.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gbps.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#gbps
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    gbps|GBPS : Gbps

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gid.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gid.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#gid
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    gid|Gid : GID

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gimp.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gimp.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#gimp
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Gimp|gimp : GIMP

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/git.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/git.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#git
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    git|GIT : Git

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gnome-classic.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gnome-classic.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#gnome-classic
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    classic mode : GNOME Classic

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gnome.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gnome.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#gnome
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Gnome|gnome : GNOME

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gnu.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gnu.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#gnu
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Gnu|gnu : GNU

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gpl.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gpl.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#gpl
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Gpl|gpl : GPL

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/grayscale.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/grayscale.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#grayscale
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    gray-scale|gray scale : grayscale

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/grub.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/grub.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#grub
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Grub : GRUB

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gtkplus.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/gtkplus.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#gtkplus
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    GTK|Gtk|gtk : GTK+

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hard-code.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hard-code.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#hard-code
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    hardcode : hard code

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hard-coded.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hard-coded.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#hard-coded
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    hardcoded : hard-coded

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/health-check.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/health-check.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#health-check
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    healthcheck|health-check : health check

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/help-desk.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/help-desk.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#help-desk
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    helpdesk|help-desk : help desk

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/host-group.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/host-group.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#host-group
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    hostgroup : host group

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/host-name.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/host-name.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#host-name
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    hostname : host name

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hot-add.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hot-add.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#hot-add
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    hotadd|hot-add : hot add

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hot-plug.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hot-plug.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#hot-plug
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    hotplug|hot-plug : hot plug

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hot-swap.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hot-swap.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#hot-swap
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    hotswap|hot-swap : hot swap

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hotline.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hotline.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#hotline
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    hot-line : hotline

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hp-proliant.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hp-proliant.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#hp-proliant
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    HP Proliant : HP ProLiant

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/huge-page-noun.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/huge-page-noun.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#huge-page-noun
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    large page|super page : huge page

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hyper-threading.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hyper-threading.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#hyper-threading
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    hyperthreading|hyper-threading : Hyper-Threading

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hyperconverged.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hyperconverged.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#hyperconverged
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    hyper-converged : hyperconverged

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hypervisor.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/hypervisor.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#hypervisor
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    HyperVisor|Hyperviser : hypervisor

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ibm-eserver-system-p.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ibm-eserver-system-p.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ibm-eserver-system-p
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    pSeries : IBM eServer System p

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ibm-s-390.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ibm-s-390.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ibm-s-390
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    S 390|S90 : IBM S 390

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ibm-z.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ibm-z.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ibm-z
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    IBM z Systems : IBM Z

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/infiniband.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/infiniband.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#infiniband
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Open InfiniBand|Infiniband : InfiniBand

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/insecure.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/insecure.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#insecure
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    nonsecure|non-secure : insecure

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/insight.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/insight.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#insight
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    GDBTK : Insight

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/installation-program.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/installation-program.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#installation-program
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    the installer : installation program

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/intel-ep80579-integrated-processor.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/intel-ep80579-integrated-processor.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#intel-ep80579-integrated-processor
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Tolapai|Intel Tolapai : Intel(R) EP80579 Integrated Processor

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/intel-virtualization-technology.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/intel-virtualization-technology.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#intel-virtualization-technology
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    VT-i|VT : Intel Virtualization Technology

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/iops.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/iops.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#iops
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Iops|IOPs : IOPS

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ip.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ip.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ip
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Ip : IP

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ipsec.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ipsec.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ipsec
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    IPSec : IPsec

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/iseries.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/iseries.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#iseries
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    iSeries : ISeries

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/iso-image.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/iso-image.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#iso-image
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    iso image : ISO image

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/iso.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/iso.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#iso
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    iso : ISO

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/itanium-2.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/itanium-2.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#itanium-2
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Itanium2 : Itanium 2

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/itanium.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/itanium.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#itanium
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    IA64|ia64 : Itanium

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/jboss-community.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/jboss-community.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#jboss-community
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    JBoss.org : JBoss Community

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/jvm.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/jvm.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#jvm
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Jvm|jvm : JVM

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/kernel-based-virtual-machine.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/kernel-based-virtual-machine.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#kernel-based-virtual-machine
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    kernel-based virtual machine : Kernel-based Virtual Machine

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/kernel-oops.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/kernel-oops.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#kernel-oops
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    oops : kernel oops

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/kernel-space-ad.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/kernel-space-ad.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#kernel-space-ad
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    kernelspace : kernel-space

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/kernel-space-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/kernel-space-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#kernel-space-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    kernelspace : kernel space

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/kickstart.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/kickstart.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#kickstart
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    kickstart : Kickstart

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/knowledge-base.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/knowledge-base.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#knowledge-base
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    knowledgebase : knowledge base

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/knowledgebase.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/knowledgebase.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#knowledgebase
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    KnowledgeBase : Knowledgebase

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/kvm.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/kvm.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#kvm
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    kvm : KVM

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/lan.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/lan.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#lan
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Lan|lan : LAN

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/linux.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/linux.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#linux
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    LINUX|linux : Linux

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/man-page.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/man-page.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#man-page
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    manpage : man page

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/many.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/many.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#many
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    lots of|bunches of : many

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/matrixes.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/matrixes.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#matrixes
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    matrices : matrixes

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/menu-driven.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/menu-driven.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#menu-driven
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    menu driven|menudriven : menu-driven

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/microsoft.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/microsoft.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#microsoft
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    MS|MSFT|MicroSoft : Microsoft

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/mouse-button.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/mouse-button.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#mouse-button
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    mouse-button|mousebutton : mouse button

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/mozilla-firefox.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/mozilla-firefox.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#mozilla-firefox
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    firefox : Mozilla Firefox

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/mozilla-thunderbird.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/mozilla-thunderbird.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#mozilla-thunderbird
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    thunderbird : Mozilla Thunderbird

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ms-dos.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ms-dos.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ms-dos
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    ms-dos|MSDOS|msdos : MS-DOS

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/multiprocessing.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/multiprocessing.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#multiprocessing
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    multi-processing : multiprocessing

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/multitenant.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/multitenant.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#multitenant
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    multi-tenant : multitenant

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/mysql.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/mysql.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#mysql
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    MYSQL|mySQL : MySQL

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/need.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/need.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#need
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    desire|wish : need

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/now.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/now.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#now
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    right now : now

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/objective-c.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/objective-c.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#objective-c
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Objective-C : Objective C

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/offline-backup.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/offline-backup.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#offline-backup
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    cold backup : offline backup

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ok.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ok.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ok
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    OK button : OK

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/omit.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/omit.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#omit
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    leave out : omit

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/opcodes.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/opcodes.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#opcodes
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    op-code : opcode

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/open-source.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/open-source.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#open-source
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    open-source|OpenSource|opensource : open source

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/operating-environment.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/operating-environment.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#operating-environment
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Operating Environment : operating environment

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/operating-system.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/operating-system.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#operating-system
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    OS|Operating System : operating system

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/opex.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/opex.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#opex
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Opex|Opex|OPEX|opEx : OpEx

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/override.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/override.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#override
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    over-ride|over ride : override

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/performance-counter.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/performance-counter.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#performance-counter
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    perfcounter : performance counter

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/plain-text.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/plain-text.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#plain-text
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    plaintext|plain-text|cleartext|clear text : plain text

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/popup.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/popup.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#popup
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    popup|Pop-up : pop-up

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/posix.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/posix.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#posix
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Posix|posix|variations : POSIX

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/postscript.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/postscript.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#postscript
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Postscript : PostScript

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/powerpc.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/powerpc.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#powerpc
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    PPC|P-PC|PPC64 : PowerPC

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ppp.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ppp.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ppp
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Ppp|ppp : PPP

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/prom.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/prom.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#prom
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    prom|Prom : PROM

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/proof-of-concept.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/proof-of-concept.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#proof-of-concept
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    proof of concepts : proof of concept

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/pseudoops.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/pseudoops.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#pseudoops
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    pseudo ops|pseudoops : pseudo-ops

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/pulldown.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/pulldown.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#pulldown
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    pull-down : pulldown

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/q-and-a.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/q-and-a.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#q-and-a
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    q & a|q&a Q & A|Q&A  : Q and A

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/qcow2.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/qcow2.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#qcow2
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    qcow2|Qcow2 : QCOW2

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/qeth.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/qeth.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#qeth
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Qeth|QETH : qeth

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ram-disk.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ram-disk.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ram-disk
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    RAMdisk|ramdisk|RAM-disk : RAM disk

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ram.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ram.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ram
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Ram|ram : RAM

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/raw.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/raw.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#raw
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    RAW : raw

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/red-hat-network-proxy-server.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/red-hat-network-proxy-server.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#red-hat-network-proxy-server
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Red Hat Proxy (Server) : Red Hat Network Proxy Server

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/red-hat-network-satellite-server.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/red-hat-network-satellite-server.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#red-hat-network-satellite-server
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Red Hat Satellite (Server) : Red Hat Network Satellite Server

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/redboot.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/redboot.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#redboot
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Redboot|Red Boot|red : RedBoot

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/remote-access-server.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/remote-access-server.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#remote-access-server
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    remote-access server : remote access server

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/remote-access.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/remote-access.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#remote-access
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    remote-access : remote access

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/repository.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/repository.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#repository
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    channel : repository

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/roll-out.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/roll-out.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#roll-out
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    rollout : roll out

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/rollout.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/rollout.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#rollout
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    roll out : rollout

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/rom.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/rom.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#rom
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Rom|rom : ROM

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/roundtable.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/roundtable.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#roundtable
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    round table : roundtable

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/rpm.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/rpm.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#rpm
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    rpm : RPM

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/runlevel.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/runlevel.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#runlevel
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    run level|run-level : runlevel

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/s-record.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/s-record.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#s-record
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    s-record|S-Record|s-Record|SREC|or any other variation : S-record

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/samba.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/samba.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#samba
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    samba|SAMBA : Samba

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/screen-saver.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/screen-saver.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#screen-saver
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    screensaver : screen saver

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/scrollbar.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/scrollbar.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#scrollbar
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    scroll bar|scroll-bar : scrollbar

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/see.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/see.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#see
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    refer to : see

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/segmentation-fault.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/segmentation-fault.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#segmentation-fault
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    segfault as a verb : segmentation fault

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/selinux.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/selinux.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#selinux
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    SE-Linux|S-E Linux|SE Linux|selinux : SELinux

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ser-iov.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ser-iov.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ser-iov
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    SR IOV : SR-IOV

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/server-cluster.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/server-cluster.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#server-cluster
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    computer farm|computer ranch : server cluster

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/server-farm.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/server-farm.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#server-farm
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    computer farm|computer ranch : server farm

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/shadow-passwords.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/shadow-passwords.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#shadow-passwords
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Shadow passwords (capitalized) : shadow passwords

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/shadow-utilities.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/shadow-utilities.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#shadow-utilities
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Shadow utilities (capitalized) : shadow utilities

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/shadowman.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/shadowman.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#shadowman
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Shadow Man|ShadowMan : Shadowman

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/share-name.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/share-name.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#share-name
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    sharename|Sharename : share name

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/shell-prompt.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/shell-prompt.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#shell-prompt
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    command prompt|terminal|shell : shell prompt

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/socks.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/socks.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#socks
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    socks : SOCKS

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/software-collection.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/software-collection.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#software-collection
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    software collection|collection|Software collection|Collection : Software Collection

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/sound-card.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/sound-card.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#sound-card
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    soundcard|sound-card : sound card

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/source-navigator.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/source-navigator.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#source-navigator
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Source Navigator (without trademark symbol) : Source-NavigatorTM

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/spec-file.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/spec-file.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#spec-file
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    specfile : spec file

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/specific.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/specific.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#specific
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Linux specific|chip specific : specific

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/spelled.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/spelled.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#spelled
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    spelt : spelled

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ssh.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ssh.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ssh
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    SSH as a verb : SSH

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ssl-tls.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ssl-tls.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ssl-tls
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    SSL|TLS|TLS SSL : SSL TLS

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/standalone.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/standalone.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#standalone
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    stand-alone : standalone

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/staroffice.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/staroffice.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#staroffice
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Star|Staroffice|Star Office : StarOffice

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/startx.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/startx.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#startx
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    StartX : startx

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/straightforward.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/straightforward.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#straightforward
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    straight forward|straight-forward : straightforward

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/su.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/su.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#su
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    SU : su

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/subcommand.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/subcommand.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#subcommand
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    sub-command : subcommand

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/subdirectory.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/subdirectory.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#subdirectory
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    sub-directory : subdirectory

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/submenu.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/submenu.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#submenu
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    sub-menu : submenu

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/subpackage.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/subpackage.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#subpackage
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    sub-package : subpackage

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/subscription.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/subscription.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#subscription
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    entitlement : subscription

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/superuser.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/superuser.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#superuser
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    super-user|super user : superuser

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/swap-space.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/swap-space.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#swap-space
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    swapspace : swap space

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/systemd.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/systemd.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#systemd
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    system D|system D|SystemD|system d|Systemd (unless at the start of a sentence). : systemd

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/sysv.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/sysv.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#sysv
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Sys V|System V : SysV

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/text-based.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/text-based.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#text-based
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    text based : text-based

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/text-mode.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/text-mode.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#text-mode
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    textmode|text-mode : text mode

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/thin-provisioned.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/thin-provisioned.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#thin-provisioned
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    thin-provisioned|thinly provisioned|thinly-provisioned : thin-provisioned

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/through.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/through.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#through
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    thru : through

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/throughput.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/throughput.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#throughput
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    thru : throughput

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/tier-1.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/tier-1.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#tier-1
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    tier-one|tier 1 : tier-1

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/time-frame.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/time-frame.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#time-frame
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    timeframe|time-frame : time frame

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ttl.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/ttl.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#ttl
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    ttl : TTL

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/uid.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/uid.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#uid
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    uid : UID

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/unix.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/unix.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#unix
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Unix|unix|UNIX-like : UNIX

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/upgrade.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/upgrade.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#upgrade
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    up-grade|up grade : upgrade

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/upsell.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/upsell.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#upsell
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    up-sell : upsell

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/upselling.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/upselling.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#upselling
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    up-selling|up selling : upselling

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/upstream-adj.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/upstream-adj.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#upstream-adj
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    up-stream|up stream : upstream

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/upstream-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/upstream-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#upstream-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    up-stream|up stream : upstream

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/uptime.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/uptime.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#uptime
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    up-time|up time : uptime

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/url.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/url.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#url
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    url : URL

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/user-space-adj.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/user-space-adj.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#user-space-adj
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    userspace : user-space

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/user-space-n.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/user-space-n.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#user-space-n
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    userspace : user space

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/var.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/var.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#var
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    var : VAR

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vdsm.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vdsm.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#vdsm
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Virtual Desktop Server Management : VDSM

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/verify.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/verify.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#verify
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    make sure : verify

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vi.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vi.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#vi
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    VI : vi

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/video-mode.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/video-mode.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#video-mode
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    video-mode|videomode : video mode

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vim.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vim.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#vim
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    VIM|vim : Vim

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/virtual-console.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/virtual-console.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#virtual-console
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    virtual-console|Virtual Console : virtual console

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/virtual.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/virtual.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#virtual
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    virtualized : virtual

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vlan.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vlan.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#vlan
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    vlan|vLAN : VLAN

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vnic.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vnic.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#vnic
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    vnic|VNIC|Virtual Network Interface Card : vNIC

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vnuma.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vnuma.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#vnuma
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    vnuma|VNUMA : vNUMA node

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vpn.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/vpn.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#vpn
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    vpn : VPN

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/wan.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/wan.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#wan
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    wan : WAN

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/want.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/want.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#want
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    wish|would like : want

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/wca.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/wca.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#wca
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    wca : WCA

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/web-ui.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/web-ui.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#web-ui
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    web-UI|webUI : web UI

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/window-maker.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/window-maker.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#window-maker
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Window-Maker|WindowMaker : Window Maker

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/write.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/write.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#write
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    code : write

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/xemacs.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/xemacs.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#xemacs
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Xemacs : XEmacs

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/xterm.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/xterm.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#xterm
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    Xterm : xterm

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/yaml.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/yaml.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#yaml
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    yaml : YAML

--- a/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/you.yml
+++ b/.vale/styles/Red-Hat-CCS/SupplementaryStyleGuide/you.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: https://redhat-documentation.github.io/supplementary-style-guide/#you
+ignorecase: true
+level: error
+action:
+  name: replace
+source: Red Hat
+swap:
+    I|he|she : you


### PR DESCRIPTION
fixes #27

Adds generated rules for every RH supplementary style guide word usage + related link to sections https://redhat-documentation.github.io/supplementary-style-guide/

All rules follow this pattern:

```
extends: substitution
message: "Use '%s' instead of '%s'."
link: https://redhat-documentation.github.io/supplementary-style-guide/#hard-code
ignorecase: true
level: error
action:
  name: replace
source: Red Hat
swap:
    hardcode : hard code
``` 

Preliminary python generation code is here: https://github.com/aireilly/supplementary-style-guide/blob/master/vale_rules/gen-vale-rules.py 