### PR TITLE
Removing CheDocs/SentenceLength.yml as a duplicate

### DIFF
--- a/.vale/styles/Red-Hat-CCS/CheDocs/SentenceLength.yml
+++ b/.vale/styles/Red-Hat-CCS/CheDocs/SentenceLength.yml
@@ -1,9 +1,0 @@
----
-extends: occurrence
-message: 'Keep sentences short and to the point'
-description: 'A good rule-of-thumb is to break up any sentence longer than 21 words into two or more separate thoughts.'
-scope: sentence
-source: PLainLanguage
-level: warning
-max: 21
-token: '\b(\w+)\b'


### PR DESCRIPTION
Removing CheDocs/SentenceLength.yml as it is a duplicate of IBM/SentenceLength.yml